### PR TITLE
Add camera usage description in Info.plist

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSCameraUsageDescription</key>
+    <string>The app requires camera access to scan barcodes.</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- create ios/Info.plist
- add `NSCameraUsageDescription` to request camera permission for scanning barcodes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841a57f95ec8332ab370a633c85e56b