### PR TITLE
Add Swift InventoryStore and tests

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PentryPal",
+    platforms: [
+        .iOS(.v13)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        .library(
+            name: "PentryPal",
+            targets: ["PentryPal"]
+        ),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "PentryPal",
+            path: "Sources/PentryPal"
+        ),
+        .testTarget(
+            name: "PentryPalTests",
+            dependencies: ["PentryPal"],
+            path: "Tests/PentryPalTests"
+        ),
+    ]
+)

--- a/ios/Sources/PentryPal/InventoryStore.swift
+++ b/ios/Sources/PentryPal/InventoryStore.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public class InventoryStore: Codable {
+    public private(set) var items: [String]
+
+    public init(items: [String] = []) {
+        self.items = items
+    }
+
+    public func add(_ item: String) {
+        items.append(item)
+    }
+
+    public func save(to url: URL) throws {
+        let data = try JSONEncoder().encode(self)
+        try data.write(to: url)
+    }
+
+    public static func load(from url: URL) throws -> InventoryStore {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(InventoryStore.self, from: data)
+    }
+}

--- a/ios/Tests/PentryPalTests/InventoryStoreTests.swift
+++ b/ios/Tests/PentryPalTests/InventoryStoreTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import PentryPal
+
+final class InventoryStoreTests: XCTestCase {
+    func testAddItem() throws {
+        let store = InventoryStore()
+        store.add("Apple")
+        XCTAssertEqual(store.items, ["Apple"])
+    }
+
+    func testSaveAndLoad() throws {
+        let store = InventoryStore()
+        store.add("Bread")
+
+        let tempDir = FileManager.default.temporaryDirectory
+        let fileURL = tempDir.appendingPathComponent("inventory.json")
+        try store.save(to: fileURL)
+
+        let loaded = try InventoryStore.load(from: fileURL)
+        XCTAssertEqual(loaded.items, ["Bread"])
+
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}
+


### PR DESCRIPTION
## Summary
- create Swift package under `ios` for iOS 13
- implement `InventoryStore` with add/save/load
- add XCTest target verifying add and persistence

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6841a582edf4833283eecb8166fd24cd