### PR TITLE
Add Swift package skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,17 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "PentryPal",
+    targets: [
+        .executableTarget(
+            name: "PentryPal",
+            path: "Sources"),
+        .testTarget(
+            name: "PentryPalTests",
+            dependencies: ["PentryPal"],
+            path: "Tests")
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # PentryPal
-PentryPal
+
+This repository now uses a Swift Package Manager setup. You can build and run
+the executable or run the unit tests using standard `swift` commands.
+
+## Building
+
+```bash
+swift build
+```
+
+## Running
+
+```bash
+swift run PentryPal
+```
+
+## Testing
+
+```bash
+swift test
+```
+

--- a/Sources/BarcodeScannerView.swift
+++ b/Sources/BarcodeScannerView.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct BarcodeScannerView {
+    func scan() -> String {
+        // Placeholder implementation
+        return "123456789"
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct ContentView {
+    var text: String = "Hello, world!"
+}

--- a/Sources/InventoryStore.swift
+++ b/Sources/InventoryStore.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class InventoryStore {
+    private(set) var items: [String] = []
+
+    func addItem(_ item: String) {
+        items.append(item)
+    }
+}

--- a/Sources/PentryPalApp.swift
+++ b/Sources/PentryPalApp.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+@main
+struct PentryPalApp {
+    static func main() {
+        print("PentryPalApp starting...")
+    }
+}

--- a/Tests/PentryPalTests/PentryPalTests.swift
+++ b/Tests/PentryPalTests/PentryPalTests.swift
@@ -1,0 +1,10 @@
+import XCTest
+@testable import PentryPal
+
+final class PentryPalTests: XCTestCase {
+    func testInventoryStoreAddItem() {
+        let store = InventoryStore()
+        store.addItem("Apple")
+        XCTAssertEqual(store.items, ["Apple"])
+    }
+}


### PR DESCRIPTION
## Summary
- setup `Package.swift` manifest
- implement basic Swift sources for the package
- add unit test target and simple test
- document how to build, run, and test with Swift Package Manager

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6841a780f6788332b4cf5d779939802b